### PR TITLE
Removing white spaces from the AttributeFlowMapping's expressions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed multiple bugs in the ADSyncRule class effected the comparing of objects.
 - Fixed dealing with standard rules.
+- Remove all whitespace from expressions in AttributeFlowMappings, otherwise they
+  will not match due to encoding  differences.
 
 ## [0.3.0] - 2024-08-07
 

--- a/source/Classes/AADSyncRule.ps1
+++ b/source/Classes/AADSyncRule.ps1
@@ -77,6 +77,23 @@ class AADSyncRule
         $currentState = Convert-ObjectToHashtable -Object $this.Get()
         $desiredState = Convert-ObjectToHashtable -Object $this
 
+        #Remove all whitespace from expressions in AttributeFlowMappings, otherwise they will not match due to encoding differences
+        foreach ($afm in $currentState.AttributeFlowMappings)
+        {
+            if (-not [string]::IsNullOrEmpty($afm.Expression))
+            {
+                $afm.Expression = $afm.Expression -replace '\s', ''
+            }
+        }
+
+        foreach ($afm in $desiredState.AttributeFlowMappings)
+        {
+            if (-not [string]::IsNullOrEmpty($afm.Expression))
+            {
+                $afm.Expression = $afm.Expression -replace '\s', ''
+            }
+        }
+
         if ($currentState.Ensure -ne $desiredState.Ensure)
         {
             return $false
@@ -224,7 +241,7 @@ class AADSyncRule
             {
                 if ($existingRule.IsStandardRule)
                 {
-                    Write-Error "It is not allowed to modify a standard rule. It can only be enabled or disabled."
+                    Write-Error 'It is not allowed to modify a standard rule. It can only be enabled or disabled.'
                     return
                 }
 


### PR DESCRIPTION
#### Pull Request (PR) description

#### This Pull Request (PR) fixes the following issues

- Remove all whitespace from expressions in AttributeFlowMappings, otherwise they will not match due to encoding  differences.

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
