### PR TITLE
Excluding property `Precedence` from comparison for standard rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Yaml and back from yaml. This is to have a hierarchy of hashtables. If
   not doing the convertion, the function `Compare-DscParameterState` in
   module `DscResource.Common` cannot compare the information in full depth.
+- Excluding property `Precedence` from comparison for standard rules.
 
 ### Fixes
 

--- a/source/Classes/AADSyncRule.ps1
+++ b/source/Classes/AADSyncRule.ps1
@@ -103,7 +103,7 @@ class AADSyncRule
 
         $param.ExcludeProperties = if ($this.IsStandardRule)
         {
-            $this.GetType().GetProperties().Name | Where-Object { $_ -in 'Connector', 'Version', 'Identifier' }
+            'Connector', 'Version', 'Identifier', 'Precedence'
         }
         else
         {


### PR DESCRIPTION
#### Pull Request (PR) description

Excluding property `Precedence` from comparison for standard rules.

#### This Pull Request (PR) fixes the following issues

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).
